### PR TITLE
Aliases as subtypes

### DIFF
--- a/driver/src/error_print.rs
+++ b/driver/src/error_print.rs
@@ -102,7 +102,7 @@ fn print_msg(input: &Input, span: Span, msg: &str) {
 
         let (number, (b, _)) = line_boundaries
             .find(|&(_, (lb, le))| lb <= span.end && le >= span.start)
-            .expect("valid span");
+            .expect("expected valid span");
         (number + 1, span.start - b + 1)
     };
 

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -1,4 +1,4 @@
-use frontend::lexer::lex;
+use frontend::{lexer::lex, print::PrettyPrintable};
 use frontend::parser::Parser;
 use frontend::sema;
 
@@ -30,9 +30,7 @@ fn main() {
 
             if let Some(unit) = sema_res.extract_value() {
                 println!("post-sema AST:");
-                for decl in unit.0.values() {
-                    decl.print();
-                }
+                unit.0.print();
 
                 let mut translator = ASTTranslator::new();
                 let program = translator.translate(unit.0);

--- a/frontend/src/ast/mod.rs
+++ b/frontend/src/ast/mod.rs
@@ -5,8 +5,6 @@ use std::rc::Rc;
 use crate::lexer::{Span, WithSpan};
 use crate::typesystem::*;
 
-pub mod print;
-
 pub type AST = HashMap<String, FnDecl>;
 
 /// Function parameter description.

--- a/frontend/src/ast/mod.rs
+++ b/frontend/src/ast/mod.rs
@@ -79,7 +79,7 @@ impl BinaryOp {
     }
 
     /// Check if the operator is some form of comparison, meaning it will return `bool`, instead of `T`.
-    /// 
+    ///
     /// This may change when operators are handled as proper method calls.
     pub fn is_cmp(&self) -> bool {
         match self {
@@ -131,6 +131,11 @@ pub enum Expr {
         tp: Rc<Type>,
         name: WithSpan<String>,
     },
+    MemberRef {
+        tp: Rc<Type>,
+        target: Box<Expr>,
+        member: WithSpan<String>,
+    },
     Call {
         tp: Rc<Type>,
         callee: Box<Expr>,
@@ -160,7 +165,9 @@ impl Expr {
             | Expr::Call { tp, .. }
             | Expr::Binary { tp, .. }
             | Expr::Block { tp, .. }
-            | Expr::If { tp, .. } => tp,
+            | Expr::If { tp, .. }
+            | Expr::MemberRef { tp, .. } => tp,
+
             Expr::Bool { .. } => &Type::Bool,
             Expr::Declare { .. } => &Type::Unit,
             Expr::Ret { .. } => &Type::Bottom,
@@ -177,7 +184,9 @@ impl Expr {
             | Expr::Call { tp, .. }
             | Expr::Binary { tp, .. }
             | Expr::Block { tp, .. }
-            | Expr::If { tp, .. } => tp.clone(),
+            | Expr::If { tp, .. }
+            | Expr::MemberRef { tp, .. } => tp.clone(),
+
             Expr::Bool { .. } => Rc::new(Type::Bool),
             Expr::Declare { .. } => Rc::new(Type::Unit),
             Expr::Ret { .. } => Rc::new(Type::Bottom),
@@ -208,6 +217,7 @@ impl Expr {
             Expr::Binary { lhs, rhs, .. } => Span::new(lhs.span().start, rhs.span().end),
             Expr::Declare { name, value, .. } => Span::new(name.span.start, value.span().end),
             Expr::Ret { span, .. } => *span,
+            Expr::MemberRef { member: member_name, .. } => member_name.span,
         }
     }
 }

--- a/frontend/src/ast/print.rs
+++ b/frontend/src/ast/print.rs
@@ -68,6 +68,10 @@ impl Expr {
             }
             Expr::Num { tp, value } => println!("Num {} {}", value.value, tp),
             Expr::Ref { tp, name } => println!("Ref {} {}", name.value, tp),
+            Expr::MemberRef { tp, target, member } => {
+                println!("MemberRef {} {}", member.value, tp);
+                target.print(depth + 1);
+            }
             Expr::Call {
                 tp, callee, args, ..
             } => {

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -2,10 +2,11 @@ pub mod ast;
 mod diagnostic;
 pub mod lexer;
 pub mod parser;
+pub mod print;
 pub mod sema;
+pub mod support;
 mod translation_unit;
 pub mod typesystem;
-pub mod support;
 
 pub use diagnostic::Diagnostic;
-pub use translation_unit::{TranslationUnit, TypeAliasMap};
+pub use translation_unit::{TranslationUnit, TypeDeclMap};

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -5,7 +5,7 @@ pub mod parser;
 pub mod print;
 pub mod sema;
 pub mod support;
-mod translation_unit;
+pub mod translation_unit;
 pub mod typesystem;
 
 pub use diagnostic::Diagnostic;

--- a/frontend/src/parser/mod.rs
+++ b/frontend/src/parser/mod.rs
@@ -77,7 +77,10 @@ impl Parser {
                 }
             }
 
-            self.get(token!(Token::EOL, Token::EOF), expected!(Token::EOL, Token::EOF))?;
+            self.get(
+                token!(Token::EOL, Token::EOF),
+                expected!(Token::EOL, Token::EOF),
+            )?;
             self.eat_while(token!(Token::EOL));
         }
 
@@ -386,7 +389,7 @@ impl Parser {
     }
 
     /// Parse term. Term can be:
-    /// 
+    ///
     /// - an expression in parentheses
     /// - a block
     /// - a conditional expression
@@ -432,10 +435,20 @@ impl Parser {
             t => Err(ParseError::new(expected!("term"), t.to_string(), span)),
         }?;
 
-        if let Token::LParen = self.lexemes.peek().value {
-            self.parse_call_expr(term)
-        } else {
-            Ok(term)
+        self.parse_postfix_operators(term)
+    }
+
+    /// Parse postfix operators like member reference and call.
+    ///
+    /// Expects the first token to be anything.
+    /// If it is not `.` or `(`, simply returns passed expression unmodified.
+    fn parse_postfix_operators(&mut self, mut expr: Expr) -> Res<Expr> {
+        loop {
+            expr = match self.lexemes.peek().value {
+                Token::LParen => self.parse_call_expr(expr)?,
+                Token::Dot => self.parse_member_ref_expr(expr)?,
+                _ => return Ok(expr),
+            }
         }
     }
 
@@ -483,6 +496,23 @@ impl Parser {
             callee: Box::new(callee),
             args,
             span,
+        })
+    }
+
+    /// Parse member reference **operator**. This means that the target is already parsed, for example:
+    ///
+    /// `foo.bar` - here target is `foo` and should already be parsed, thus the input to `parse_member_ref_expr` should be `.bar`.
+    ///
+    /// Expects the first token to be `.`.
+    fn parse_member_ref_expr(&mut self, target: Expr) -> Res<Expr> {
+        self.get(token!(Token::Dot), expected!(Token::Dot))?;
+
+        let name = self.parse_id()?;
+
+        Ok(Expr::MemberRef {
+            tp: Rc::new(Type::Undef),
+            target: Box::new(target),
+            member: name,
         })
     }
 

--- a/frontend/src/parser/res.rs
+++ b/frontend/src/parser/res.rs
@@ -22,6 +22,12 @@ impl ParseError {
             span,
         }
     }
+
+    /// Replace `expected` with given list.
+    pub fn expect(mut self, expected: Vec<String>) -> Self {
+        self.expected = expected;
+        self
+    }
 }
 
 /// Create a prettified message from a list of expected items and the actual item.

--- a/frontend/src/print/mod.rs
+++ b/frontend/src/print/mod.rs
@@ -1,0 +1,10 @@
+mod pretty_printable;
+pub use pretty_printable::PrettyPrintable;
+
+mod ast;
+
+fn make_offset(depth: u8) {
+    for _ in 0..depth {
+        print!("  ");
+    }
+}

--- a/frontend/src/print/pretty_printable.rs
+++ b/frontend/src/print/pretty_printable.rs
@@ -1,0 +1,7 @@
+pub trait PrettyPrintable {
+    fn print_with_depth(&self, depth: u8);
+
+    fn print(&self) {
+        self.print_with_depth(0);
+    }
+}

--- a/frontend/src/sema/mod.rs
+++ b/frontend/src/sema/mod.rs
@@ -14,8 +14,10 @@ use crate::{TranslationUnit, ast::*, typesystem::TypeDecl};
 pub fn run(fn_decls: Vec<FnDecl>, type_decls: Vec<TypeDecl>) -> Res<TranslationUnit> {
     let mut passes = HandleImplicitRets {}
         .and_then(TypeNameCorrectnessCheck {})
+        .and_then(TypeAliasLoopCheck {})
         .and_then(NameCorrectnessCheck {})
         .and_then(AssignmentCorrectnessCheck {})
+        .and_then(UnaliasStructTypes {})
         .and_then(Typing {});
 
     passes.run((fn_decls, type_decls))

--- a/frontend/src/sema/passes/assignment_correctness_check.rs
+++ b/frontend/src/sema/passes/assignment_correctness_check.rs
@@ -15,6 +15,9 @@ fn is_expr_assignable(ctx: &MutableVars, expr: &Expr) -> bool {
         Expr::Num { .. } | Expr::Bool { .. } | Expr::Ret { .. } | Expr::Declare { .. } => false,
         Expr::Ref { name, .. } => ctx.contains(name.value.as_str()),
 
+        // TODO: change this when methods are added, they should not be reassignable
+        Expr::MemberRef { target, .. } => is_expr_assignable(ctx, target),
+
         Expr::If { .. }
         | Expr::While { .. }
         | Expr::Call { .. }
@@ -25,21 +28,22 @@ fn is_expr_assignable(ctx: &MutableVars, expr: &Expr) -> bool {
 
 /// Recursively go through expression tree, find expressions like `dest = src` and
 /// verify that their destination operand is an expression that is assignable to
-fn check_expr_assignments<'a, 'b: 'a>(
+fn check_expr_for_assignments<'a, 'b: 'a>(
     diags: &mut Vec<Diagnostic>,
     ctx: &'a mut MutableVars<'b>,
     expr: &'b Expr,
 ) {
     match expr {
         Expr::Num { .. } | Expr::Ref { .. } | Expr::Bool { .. } => {}
+        Expr::MemberRef { target, .. } => check_expr_for_assignments(diags, ctx, target),
         Expr::Call { callee, args, .. } => {
-            check_expr_assignments(diags, ctx, callee);
+            check_expr_for_assignments(diags, ctx, callee);
             args.iter()
-                .for_each(|arg| check_expr_assignments(diags, ctx, arg));
+                .for_each(|arg| check_expr_for_assignments(diags, ctx, arg));
         }
         Expr::While { cond, body, .. } => {
-            check_expr_assignments(diags, ctx, cond);
-            check_expr_assignments(diags, ctx, body);
+            check_expr_for_assignments(diags, ctx, cond);
+            check_expr_for_assignments(diags, ctx, body);
         }
         Expr::If {
             cond,
@@ -47,10 +51,10 @@ fn check_expr_assignments<'a, 'b: 'a>(
             on_false,
             ..
         } => {
-            check_expr_assignments(diags, ctx, cond);
-            check_expr_assignments(diags, ctx, on_true);
+            check_expr_for_assignments(diags, ctx, cond);
+            check_expr_for_assignments(diags, ctx, on_true);
             if let Some(on_false) = on_false {
-                check_expr_assignments(diags, ctx, on_false);
+                check_expr_for_assignments(diags, ctx, on_false);
             }
         }
         Expr::Binary {
@@ -69,12 +73,12 @@ fn check_expr_assignments<'a, 'b: 'a>(
                     *op_span,
                 ))
             }
-            check_expr_assignments(diags, ctx, lhs);
-            check_expr_assignments(diags, ctx, rhs);
+            check_expr_for_assignments(diags, ctx, lhs);
+            check_expr_for_assignments(diags, ctx, rhs);
         }
         Expr::Binary { lhs, rhs, .. } => {
-            check_expr_assignments(diags, ctx, lhs);
-            check_expr_assignments(diags, ctx, rhs);
+            check_expr_for_assignments(diags, ctx, lhs);
+            check_expr_for_assignments(diags, ctx, rhs);
         }
         Expr::Declare {
             is_mut,
@@ -82,7 +86,7 @@ fn check_expr_assignments<'a, 'b: 'a>(
             value,
             ..
         } => {
-            check_expr_assignments(diags, ctx, value);
+            check_expr_for_assignments(diags, ctx, value);
             if *is_mut {
                 ctx.insert(&name.value);
             }
@@ -90,12 +94,12 @@ fn check_expr_assignments<'a, 'b: 'a>(
         Expr::Block { body, .. } => {
             ctx.enter_scope();
             body.iter()
-                .for_each(|e| check_expr_assignments(diags, ctx, e));
+                .for_each(|e| check_expr_for_assignments(diags, ctx, e));
             ctx.leave_scope();
         }
         Expr::Ret { value, .. } => {
             if let Some(e) = value {
-                check_expr_assignments(diags, ctx, e);
+                check_expr_for_assignments(diags, ctx, e);
             }
         }
     }
@@ -110,7 +114,7 @@ fn check_decl_for_assignments(diags: &mut Vec<Diagnostic>, decl: &FnDecl) {
             .collect(),
     );
 
-    check_expr_assignments(diags, &mut ctx, &decl.body)
+    check_expr_for_assignments(diags, &mut ctx, &decl.body)
 }
 
 impl Pass for AssignmentCorrectnessCheck {
@@ -120,7 +124,8 @@ impl Pass for AssignmentCorrectnessCheck {
     fn run(&mut self, (ast, typemap): Self::Input) -> Res<Self::Output> {
         let mut diags = vec![];
 
-        ast.values().for_each(|decl| check_decl_for_assignments(&mut diags, decl));
+        ast.values()
+            .for_each(|decl| check_decl_for_assignments(&mut diags, decl));
 
         if diags.is_empty() {
             Res::Ok((ast, typemap))

--- a/frontend/src/sema/passes/ast_printer.rs
+++ b/frontend/src/sema/passes/ast_printer.rs
@@ -1,0 +1,3 @@
+use super::{Pass, Res};
+use crate::ast::*;
+use crate::typesystem::{Type, TypeDecl};

--- a/frontend/src/sema/passes/handle_implicit_rets.rs
+++ b/frontend/src/sema/passes/handle_implicit_rets.rs
@@ -74,6 +74,7 @@ fn set_all_returned_conditionals_to_expr_pos(e: &mut Expr) {
                 set_all_returned_conditionals_to_expr_pos(on_false);
             }
         }
+        Expr::MemberRef { target, .. } => set_all_returned_conditionals_to_expr_pos(target),
         Expr::Num { .. } | Expr::Bool { .. } | Expr::Ref { .. } | Expr::Call { .. } => {}
         Expr::Binary { lhs, rhs, .. } => {
             set_all_returned_conditionals_to_expr_pos(lhs);
@@ -95,7 +96,8 @@ fn find_implicit_ret_candidate(root: &mut Expr) -> &mut Expr {
         | Expr::Call { .. }
         | Expr::Binary { .. }
         | Expr::While { .. }
-        | Expr::If { .. } => root,
+        | Expr::If { .. }
+        | Expr::MemberRef { .. } => root,
         Expr::Block { body, .. } if body.is_empty() => root,
         Expr::Block { body, .. } => body.last_mut().map(find_implicit_ret_candidate).unwrap(),
     }

--- a/frontend/src/sema/passes/mod.rs
+++ b/frontend/src/sema/passes/mod.rs
@@ -12,5 +12,11 @@ pub use name_correctness_check::NameCorrectnessCheck;
 mod assignment_correctness_check;
 pub use assignment_correctness_check::AssignmentCorrectnessCheck;
 
+mod unalias_struct_types;
+pub use unalias_struct_types::UnaliasStructTypes;
+
+mod type_alias_loop_check;
+pub use type_alias_loop_check::TypeAliasLoopCheck;
+
 mod typing;
 pub use typing::Typing;

--- a/frontend/src/sema/passes/name_correctness_check.rs
+++ b/frontend/src/sema/passes/name_correctness_check.rs
@@ -6,7 +6,6 @@ use crate::TranslationUnit;
 use crate::TypeDeclMap;
 use crate::ast::*;
 use crate::lexer::WithSpan;
-use crate::print::PrettyPrintable;
 use crate::support::ScopedSet;
 
 /// Pass ther checks that all references to named values (variables, parameters, functions) are valid.
@@ -17,7 +16,6 @@ type Names<'a> = ScopedSet<&'a str>;
 fn check_references_in_expr<'a>(diags: &mut Vec<Diagnostic>, ctx: &mut Names<'a>, expr: &'a Expr) {
     match expr {
         Expr::Ref { name, .. } => {
-            eprintln!("ctx on check of ref to {}:\n{:?}", name.value, ctx);
             if !ctx.contains(name.value.as_str()) {
                 diags.push(Diagnostic::new(
                     format!("reference to undefined name {}", name.value),

--- a/frontend/src/sema/passes/name_correctness_check.rs
+++ b/frontend/src/sema/passes/name_correctness_check.rs
@@ -38,6 +38,11 @@ fn check_references_in_expr<'a>(diags: &mut Vec<Diagnostic>, ctx: &mut Names<'a>
                 check_references_in_expr(diags, ctx, on_false);
             }
         }
+        
+        // sadly we cannot check validity of field reference here,
+        // because expression type is unknown at this point
+        Expr::MemberRef { target, .. } => check_references_in_expr(diags, ctx, target),
+
         Expr::Call { callee, args, .. } => {
             check_references_in_expr(diags, ctx, callee);
             for arg in args {

--- a/frontend/src/sema/passes/type_alias_loop_check.rs
+++ b/frontend/src/sema/passes/type_alias_loop_check.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+
+use crate::{
+    Diagnostic, TypeDeclMap,
+    ast::FnDecl,
+    typesystem::{Type, TypeDecl},
+};
+
+use super::{Pass, Res};
+
+pub struct TypeAliasLoopCheck {}
+
+impl Pass for TypeAliasLoopCheck {
+    type Input = (Vec<FnDecl>, TypeDeclMap);
+    type Output = (Vec<FnDecl>, TypeDeclMap);
+
+    fn run(&mut self, (fn_decls, type_decl_map): Self::Input) -> Res<Self::Output> {
+        let mut diags = Vec::new();
+
+        for type_decl in type_decl_map.decls() {
+            check_alias_loops(&mut diags, &type_decl_map, type_decl);
+        }
+
+        if diags.is_empty() {
+            Res::Ok((fn_decls, type_decl_map))
+        } else {
+            Res::Fatal(diags)
+        }
+    }
+}
+
+fn check_alias_loops<'a: 'b, 'b>(
+    diags: &mut Vec<Diagnostic>,
+    type_decl_map: &'a TypeDeclMap,
+    mut type_decl: &'b TypeDecl,
+) {
+    let mut seen_names: HashSet<&str> = HashSet::new();
+    seen_names.insert(&type_decl.name.value);
+
+    loop {
+        match type_decl.value.value.as_ref() {
+            Type::Alias(name) if seen_names.contains(name.as_str()) => {
+                diags.push(Diagnostic::new(
+                    format!(
+                        "loop in type alias initializer: alias {} repeats in the chain",
+                        name
+                    ),
+                    type_decl.name.span,
+                ));
+                return;
+            }
+            Type::Alias(name) => {
+                seen_names.insert(name);
+                type_decl = type_decl_map
+                    .get_decl(&name)
+                    .expect("expected valid type alias, see `TypeNameCorrectnessChec` pass");
+            }
+            _ => {
+                return;
+            }
+        }
+    }
+}

--- a/frontend/src/sema/passes/typename_correctness_check.rs
+++ b/frontend/src/sema/passes/typename_correctness_check.rs
@@ -32,7 +32,7 @@ fn check_tp(diags: &mut Vec<Diagnostic>, tp: &Type, type_alias_map: &TypeAliasMa
         // cannot be written explicitly yet
         Type::Function { .. } => unreachable!(),
 
-        Type::Struct(fields) => fields
+        Type::Struct { fields, .. } => fields
             .iter()
             .for_each(|t| check_tp(diags, &t.tp.value, type_alias_map, t.tp.span)),
     }

--- a/frontend/src/sema/passes/typename_correctness_check.rs
+++ b/frontend/src/sema/passes/typename_correctness_check.rs
@@ -55,6 +55,7 @@ fn check_typename_usage_in_expr(
         | Expr::Bool { .. }
         | Expr::Ref { .. }
         | Expr::Call { .. }
+        | Expr::MemberRef { .. }
         | Expr::Binary { .. } => {}
     }
 }

--- a/frontend/src/sema/passes/typing.rs
+++ b/frontend/src/sema/passes/typing.rs
@@ -3,296 +3,390 @@ use std::rc::Rc;
 use super::util::for_each_expr;
 use super::{Pass, Res};
 
-use crate::Diagnostic;
 use crate::TranslationUnit;
 use crate::ast::*;
 use crate::lexer::{Span, WithSpan};
 use crate::support::ScopedMap;
 use crate::typesystem::Type;
+use crate::{Diagnostic, TypeAliasMap};
 
-type Ctx = ScopedMap<String, Rc<Type>>;
+type DeclTypeMap = ScopedMap<String, Rc<Type>>;
 
 /// Pass for type inference and type checking.
 ///
 /// Does a lot of work like checking variable declarations, expression type correctness and return type checking, because all of this needs a lot of context that is gathered during this pass.
 pub struct Typing {}
 
-/// Deduce and check types in declaration body
-fn type_decl_body(diags: &mut Vec<Diagnostic>, typemap: &mut Ctx, decl: &mut FnDecl) {
-    typemap.enter_scope();
+struct TypingImpl<'a> {
+    pub diags: Vec<Diagnostic>,
+    typemap: DeclTypeMap,
+    alias_map: &'a TypeAliasMap,
+}
 
-    for FnParam { name, tp, .. } in &decl.params {
-        typemap.insert(name.value.clone(), tp.value.clone());
+impl<'a> TypingImpl<'a> {
+    /// Deduce and check types in declaration body
+    fn type_decl_body(&mut self, decl: &mut FnDecl) {
+        self.typemap.enter_scope();
+
+        for FnParam { name, tp, .. } in &decl.params {
+            self.typemap.insert(name.value.clone(), tp.value.clone());
+        }
+
+        self.type_expr(&mut decl.body);
+
+        self.check_ret_type(&decl);
+
+        self.typemap.leave_scope();
     }
 
-    type_expr(diags, typemap, &mut decl.body);
+    /// Find all `ret` expressions in function body and check that their argument type matches the return type of the function.
+    fn check_ret_type(&mut self, decl: &FnDecl) {
+        let check_ret = |value: Option<&Expr>, span: Span| -> Option<Diagnostic> {
+            let tp = value.map(|e| e.tp()).unwrap_or(&Type::Unit);
+            if !match_types(tp, &decl.return_type.value) {
+                let msg = format!(
+                    "return type mismatch: expected {}, but got {}",
+                    decl.return_type.value, tp
+                );
+                let note = WithSpan::new(
+                    "function return type declared here".to_string(),
+                    decl.return_type.span,
+                );
+                Some(Diagnostic::new_with_notes(msg, span, vec![note]))
+            } else {
+                None
+            }
+        };
 
-    check_ret_type(diags, &decl);
+        for_each_expr(
+            &mut |e: &Expr| {
+                if let Expr::Ret { value, span } = e {
+                    if let Some(diag) = check_ret(value.as_ref().map(|b| b.as_ref()), *span) {
+                        self.diags.push(diag);
+                    }
+                }
+            },
+            &decl.body,
+        );
+    }
 
-    typemap.leave_scope();
-}
+    /// Recursively go through expression tree, deduce types where needed and possible,
+    /// and check that all types are valid and compatible.
+    ///
+    /// If typing fails, expression type is set to `bottom`, so that it does not break anything further.
+    fn type_expr(&mut self, expr: &mut Expr) {
+        match expr {
+            Expr::Num { tp, value } => {
+                // TODO: check that `tp` is valid and can contain the literal
 
-/// Find all `ret` expressions in function body and check that their argument type matches the return type of the function.
-fn check_ret_type(diags: &mut Vec<Diagnostic>, decl: &FnDecl) {
-    let check_ret = |value: Option<&Expr>, span: Span| -> Option<Diagnostic> {
-        let tp = value.map(|e| e.tp()).unwrap_or(&Type::Unit);
-        if !match_types(tp, &decl.return_type.value) {
-            let msg = format!(
-                "return type mismatch: expected {}, but got {}",
-                decl.return_type.value, tp
-            );
-            let note = WithSpan::new(
-                "function return type declared here".to_string(),
-                decl.return_type.span,
-            );
-            Some(Diagnostic::new_with_notes(msg, span, vec![note]))
-        } else {
-            None
-        }
-    };
-
-    for_each_expr(
-        &mut |e: &Expr| {
-            if let Expr::Ret { value, span } = e {
-                if let Some(diag) = check_ret(value.as_ref().map(|b| b.as_ref()), *span) {
-                    diags.push(diag);
+                if let Type::Undef = tp.as_ref() {
+                    *tp = Rc::new(deduce_integer_type(value.value));
                 }
             }
-        },
-        &decl.body,
-    );
-}
-
-/// Recursively go through expression tree, deduce types where needed and possible,
-/// and check that all types are valid and compatible.
-///
-/// If typing fails, expression type is set to `bottom`, so that it does not break anything further.
-fn type_expr(diags: &mut Vec<Diagnostic>, typemap: &mut Ctx, expr: &mut Expr) {
-    match expr {
-        Expr::Num { tp, value } => {
-            // TODO: check that `tp` is valid and can contain the literal
-
-            if let Type::Undef = tp.as_ref() {
-                *tp = Rc::new(deduce_integer_type(value.value));
+            Expr::Bool { .. } => {}
+            Expr::Ref { tp, name } => {
+                *tp = self
+                    .typemap
+                    .get(&name.value)
+                    .expect("valid reference")
+                    .clone();
             }
-        }
-        Expr::Bool { .. } => {}
-        Expr::Ref { tp, name } => {
-            *tp = typemap.get(&name.value).expect("valid reference").clone();
-        }
-        Expr::If {
-            tp,
-            cond,
-            on_true,
-            on_false,
-            kw_span,
-            in_stmt_pos,
-        } => {
-            type_expr(diags, typemap, cond);
-            type_expr(diags, typemap, on_true);
-            if let Some(on_false) = on_false {
-                type_expr(diags, typemap, on_false);
-            }
+            Expr::MemberRef { tp, target, member } => {
+                self.type_expr(target);
 
-            if !match_types(cond.tp(), &Type::Bool) {
-                diags.push(Diagnostic::new(
-                    format!(
-                        "invalid type for condition: expected {}, but got {}",
-                        Type::Bool,
-                        cond.tp(),
-                    ),
-                    cond.span(),
-                ));
-            }
-
-            if *in_stmt_pos {
-                // in statement position we do not care about the type of the conditional,
-                // its value is ignored either way
-                *tp = Rc::new(Type::Unit);
-            } else {
-                if let Some(on_false) = on_false {
-                    // in expression position, check that both `then` and `else` branches have the same type
-                    *tp = merge_types(on_true.tp_rc(), on_false.tp_rc()).unwrap_or_else(|| {
-                        let then_note =
-                            WithSpan::new(format!("`then` is {}", on_true.tp()), on_true.span());
-                        let else_note =
-                            WithSpan::new(format!("`else` is {}", on_false.tp()), on_false.span());
-                        diags.push(Diagnostic::new_with_notes(
-                            "branches types mismatch".to_string(),
-                            *kw_span,
-                            vec![then_note, else_note],
+                *tp = self
+                    .get_member_type(target, member.value.as_str())
+                    .unwrap_or_else(|| {
+                        self.diags.push(Diagnostic::new(
+                            format!(
+                                "expression of type {} has no member {}",
+                                target.tp(),
+                                member.value
+                            ),
+                            member.span,
                         ));
-
                         Rc::new(Type::Bottom)
                     })
-                } else {
-                    // otherwise if `else` branch is not present in expression position,
-                    // conditional expression is invaid
-                    *tp = Rc::new(Type::Bottom);
+            }
+            Expr::If {
+                tp,
+                cond,
+                on_true,
+                on_false,
+                kw_span,
+                in_stmt_pos,
+            } => {
+                self.type_expr(cond);
+                self.type_expr(on_true);
+                if let Some(on_false) = on_false {
+                    self.type_expr(on_false);
+                }
 
-                    diags.push(Diagnostic::new(
-                        "conditional expression is missing the `else` branch".to_string(),
-                        expr.span(),
+                if !match_types(cond.tp(), &Type::Bool) {
+                    self.diags.push(Diagnostic::new(
+                        format!(
+                            "invalid type for condition: expected {}, but got {}",
+                            Type::Bool,
+                            cond.tp(),
+                        ),
+                        cond.span(),
+                    ));
+                }
+
+                if *in_stmt_pos {
+                    // in statement position we do not care about the type of the conditional,
+                    // its value is ignored either way
+                    *tp = Rc::new(Type::Unit);
+                } else {
+                    if let Some(on_false) = on_false {
+                        // in expression position, check that both `then` and `else` branches have the same type
+                        *tp = merge_types(on_true.tp_rc(), on_false.tp_rc()).unwrap_or_else(|| {
+                            let then_note = WithSpan::new(
+                                format!("`then` is {}", on_true.tp()),
+                                on_true.span(),
+                            );
+                            let else_note = WithSpan::new(
+                                format!("`else` is {}", on_false.tp()),
+                                on_false.span(),
+                            );
+                            self.diags.push(Diagnostic::new_with_notes(
+                                "branches types mismatch".to_string(),
+                                *kw_span,
+                                vec![then_note, else_note],
+                            ));
+
+                            Rc::new(Type::Bottom)
+                        })
+                    } else {
+                        // otherwise if `else` branch is not present in expression position,
+                        // conditional expression is invaid
+                        *tp = Rc::new(Type::Bottom);
+
+                        self.diags.push(Diagnostic::new(
+                            "conditional expression is missing the `else` branch".to_string(),
+                            expr.span(),
+                        ));
+                    }
+                }
+            }
+            Expr::While { cond, body, .. } => {
+                self.type_expr(cond);
+                self.type_expr(body);
+
+                if !match_types(cond.tp(), &Type::Bool) {
+                    self.diags.push(Diagnostic::new(
+                        format!(
+                            "invalid type for while loop condition: expected {}, but got {}",
+                            Type::Bool,
+                            cond.tp(),
+                        ),
+                        cond.span(),
                     ));
                 }
             }
-        }
-        Expr::While { cond, body, .. } => {
-            type_expr(diags, typemap, cond);
-            type_expr(diags, typemap, body);
+            Expr::Call {
+                tp,
+                callee,
+                args,
+                span: call_span,
+            } => {
+                self.type_expr(callee);
 
-            if !match_types(cond.tp(), &Type::Bool) {
-                diags.push(Diagnostic::new(
-                    format!(
-                        "invalid type for while loop condition: expected {}, but got {}",
-                        Type::Bool,
-                        cond.tp(),
-                    ),
-                    cond.span(),
-                ));
-            }
-        }
-        Expr::Call {
-            tp,
-            callee,
-            args,
-            span: call_span,
-        } => {
-            type_expr(diags, typemap, callee);
+                args.iter_mut().for_each(|arg| self.type_expr(arg));
 
-            args.iter_mut()
-                .for_each(|arg| type_expr(diags, typemap, arg));
-
-            *tp = if let Type::Function { params, rettype } = callee.tp() {
-                check_call_args(diags, *call_span, params, &args);
-                rettype.clone()
-            } else {
-                diags.push(Diagnostic::new(
-                    "expression is not callable".to_string(),
-                    callee.span(),
-                ));
-                Rc::new(Type::Bottom)
-            }
-        }
-        Expr::Binary { tp, op, lhs, rhs } => {
-            type_expr(diags, typemap, lhs);
-            type_expr(diags, typemap, rhs);
-
-            let mut report_incompatible_types = || {
-                let note_lhs = WithSpan::new(format!("left is {}", lhs.tp()), lhs.span());
-                let note_rhs = WithSpan::new(format!("right is {}", rhs.tp()), rhs.span());
-                diags.push(Diagnostic::new_with_notes(
-                    "incompatible types for operation".to_string(),
-                    op.span,
-                    vec![note_lhs, note_rhs],
-                ))
-            };
-
-            *tp = if op.value.is_cmp() {
-                if !match_types(lhs.tp(), rhs.tp()) {
-                    report_incompatible_types();
-                }
-                Rc::new(Type::Bool)
-            } else {
-                merge_types(lhs.tp_rc(), rhs.tp_rc()).unwrap_or_else(|| {
-                    report_incompatible_types();
+                *tp = if let Type::Function { params, rettype } = callee.tp() {
+                    self.check_call_args(*call_span, params, &args);
+                    rettype.clone()
+                } else {
+                    self.diags.push(Diagnostic::new(
+                        "expression is not callable".to_string(),
+                        callee.span(),
+                    ));
                     Rc::new(Type::Bottom)
-                })
-            };
-        }
-        Expr::Declare {
-            tp, value, name, ..
-        } => {
-            if let Type::Undef = *tp.value {
-                type_expr(diags, typemap, value);
-                tp.value = value.tp_rc().clone();
-            } else {
-                propagate_type(diags, value, tp.value.clone());
-                type_expr(diags, typemap, value);
-
-                if !match_types(value.tp(), &tp.value) {
-                    let msg = format!(
-                        "initializer type mismatch: expected {}, but got {}",
-                        tp.value,
-                        value.tp()
-                    );
-                    let note = WithSpan::new("variable type declared here".to_string(), tp.span);
-                    diags.push(Diagnostic::new_with_notes(msg, value.span(), vec![note]));
                 }
             }
+            Expr::Binary { tp, op, lhs, rhs } => {
+                self.type_expr(lhs);
+                self.type_expr(rhs);
 
-            typemap.insert(name.value.clone(), tp.value.clone());
-        }
-        Expr::Block { tp, body, .. } => {
-            typemap.enter_scope();
+                let mut report_incompatible_types = || {
+                    let note_lhs = WithSpan::new(format!("left is {}", lhs.tp()), lhs.span());
+                    let note_rhs = WithSpan::new(format!("right is {}", rhs.tp()), rhs.span());
+                    self.diags.push(Diagnostic::new_with_notes(
+                        "incompatible types for operation".to_string(),
+                        op.span,
+                        vec![note_lhs, note_rhs],
+                    ))
+                };
 
-            body.iter_mut().for_each(|e| type_expr(diags, typemap, e));
+                *tp = if op.value.is_cmp() {
+                    if !match_types(lhs.tp(), rhs.tp()) {
+                        report_incompatible_types();
+                    }
+                    Rc::new(Type::Bool)
+                } else {
+                    merge_types(lhs.tp_rc(), rhs.tp_rc()).unwrap_or_else(|| {
+                        report_incompatible_types();
+                        Rc::new(Type::Bottom)
+                    })
+                };
+            }
+            Expr::Declare {
+                tp, value, name, ..
+            } => {
+                if let Type::Undef = *tp.value {
+                    self.type_expr(value);
+                    tp.value = value.tp_rc().clone();
+                } else {
+                    self.propagate_type(value, tp.value.clone());
+                    self.type_expr(value);
 
-            *tp = body
-                .last()
-                .map(|e| e.tp_rc())
-                .unwrap_or_else(|| Rc::new(Type::Unit));
+                    if !match_types(value.tp(), &tp.value) {
+                        let msg = format!(
+                            "initializer type mismatch: expected {}, but got {}",
+                            tp.value,
+                            value.tp()
+                        );
+                        let note =
+                            WithSpan::new("variable type declared here".to_string(), tp.span);
+                        self.diags
+                            .push(Diagnostic::new_with_notes(msg, value.span(), vec![note]));
+                    }
+                }
 
-            typemap.leave_scope();
-        }
-        Expr::Ret { value, .. } => {
-            if let Some(value) = value {
-                type_expr(diags, typemap, value);
+                self.typemap.insert(name.value.clone(), tp.value.clone());
+            }
+            Expr::Block { tp, body, .. } => {
+                self.typemap.enter_scope();
+
+                body.iter_mut().for_each(|e| self.type_expr(e));
+
+                *tp = body
+                    .last()
+                    .map(|e| e.tp_rc())
+                    .unwrap_or_else(|| Rc::new(Type::Unit));
+
+                self.typemap.leave_scope();
+            }
+            Expr::Ret { value, .. } => {
+                if let Some(value) = value {
+                    self.type_expr(value);
+                }
             }
         }
     }
-}
 
-/// Try set given type to the expression and all its subexpressions. This is used when the type is known and should be propagated rather than deduced.
-fn propagate_type(diags: &mut Vec<Diagnostic>, expr: &mut Expr, propagated: Rc<Type>) {
-    match expr {
-        Expr::Declare { .. } | Expr::Ret { .. } => {} // always unit and bottom respectively
+    /// Unwrap any nested type aliases until we get a concrete type.
+    fn unalias_type<'b>(&'b self, tp: &'b Type) -> &'b Type {
+        let mut cur = tp;
+        while let Type::Alias(name) = cur {
+            let typedecl = self
+                .alias_map
+                .get(name)
+                .expect("expected valid alias, check `TypeNameCorrectnessCheck` pass");
 
-        Expr::Block { tp, body, .. } => {
-            *tp = propagated.clone();
-            if let Some(e) = body.last_mut() {
-                propagate_type(diags, e, propagated);
+            cur = typedecl.value.value.as_ref();
+        }
+        cur
+    }
+
+    fn get_member_type(&self, target: &Expr, member: &str) -> Option<Rc<Type>> {
+        match self.unalias_type(target.tp()) {
+            Type::Bottom => Some(Rc::new(Type::Bottom)),
+            Type::Struct(fields) => fields
+                .iter()
+                .find(|field| field.name == member)
+                .map(|field| field.tp.value.clone()),
+            _ => None,
+        }
+    }
+
+    /// Try set given type to the expression and all its subexpressions. This is used when the type is known and should be propagated rather than deduced.
+    fn propagate_type(&mut self, expr: &mut Expr, propagated: Rc<Type>) {
+        match expr {
+            Expr::Declare { .. } | Expr::Ret { .. } => {} // always unit and bottom respectively
+
+            Expr::Block { tp, body, .. } => {
+                *tp = propagated.clone();
+                if let Some(e) = body.last_mut() {
+                    self.propagate_type(e, propagated);
+                }
+            }
+            Expr::If { on_false: None, .. } => {}
+            Expr::If {
+                tp,
+                on_true,
+                on_false: Some(on_false),
+                ..
+            } => {
+                *tp = propagated.clone();
+                self.propagate_type(on_true, propagated.clone());
+                self.propagate_type(on_false, propagated);
+            }
+            Expr::Num {
+                tp,
+                value: WithSpan { span, .. },
+            } => {
+                *tp = if propagated.is_integer() {
+                    propagated.clone()
+                } else {
+                    self.diags.push(Diagnostic::new(
+                        format!("integer literal cannot have type {}", *propagated),
+                        *span,
+                    ));
+                    Rc::new(Type::Bottom)
+                }
+            }
+
+            Expr::While { .. } => {} // will change in the future, see issue #18
+
+            // these types should always be set in `type_expr` by lookup
+            Expr::Ref { .. } | Expr::Call { .. } | Expr::MemberRef { .. } => {}
+
+            Expr::Binary { op, .. } if op.value.is_cmp() => {} // always bool
+            Expr::Bool { .. } => {}                            // always bool
+
+            Expr::Binary { tp, lhs, rhs, .. } => {
+                *tp = propagated.clone();
+                self.propagate_type(lhs, propagated.clone());
+                self.propagate_type(rhs, propagated);
             }
         }
-        Expr::If { on_false: None, .. } => {}
-        Expr::If {
-            tp,
-            on_true,
-            on_false: Some(on_false),
-            ..
-        } => {
-            *tp = propagated.clone();
-            propagate_type(diags, on_true, propagated.clone());
-            propagate_type(diags, on_false, propagated);
-        }
-        Expr::Num {
-            tp,
-            value: WithSpan { span, .. },
-        } => {
-            *tp = if propagated.is_integer() {
-                propagated.clone()
-            } else {
-                diags.push(Diagnostic::new(
-                    format!("integer literal cannot have type {}", *propagated),
-                    *span,
-                ));
-                Rc::new(Type::Bottom)
-            }
+    }
+
+    /// Check that function call arguments are in the expected amount and their types match those declared.
+    fn check_call_args<T: AsRef<Type>>(&mut self, call_span: Span, params: &[T], args: &[Expr]) {
+        if args.len() != params.len() {
+            self.diags.push(Diagnostic::new(
+                format!(
+                    "too {} arguments passed to function: expected {}, but got {}",
+                    if args.len() < params.len() {
+                        "few"
+                    } else {
+                        "many"
+                    },
+                    params.len(),
+                    args.len()
+                ),
+                call_span,
+            ));
         }
 
-        Expr::While { .. } => {} // will change in the future, see issue #18
-
-        // these types should always be set in `type_expr` by lookup
-        Expr::Ref { .. } | Expr::Call { .. } => {}
-
-        Expr::Binary { op, .. } if op.value.is_cmp() => {} // always bool
-        Expr::Bool { .. } => {}                            // always bool
-
-        Expr::Binary { tp, lhs, rhs, .. } => {
-            *tp = propagated.clone();
-            propagate_type(diags, lhs, propagated.clone());
-            propagate_type(diags, rhs, propagated);
-        }
+        params
+            .iter()
+            .zip(args)
+            .filter(|(param, arg)| !match_types(arg.tp(), param.as_ref()))
+            .map(|(param, arg)| {
+                Diagnostic::new(
+                    format!(
+                        "argument type mismatch: expected {}, but got {}",
+                        param.as_ref(),
+                        arg.tp()
+                    ),
+                    arg.span(),
+                )
+            })
+            .for_each(|diag| self.diags.push(diag));
     }
 }
 
@@ -319,48 +413,8 @@ fn deduce_integer_type(_value: u64) -> Type {
     Type::I64 // TODO: unhardcode this
 }
 
-/// Check that function call arguments are in the expected amount and their types match those declared.
-fn check_call_args<T: AsRef<Type>>(
-    diags: &mut Vec<Diagnostic>,
-    call_span: Span,
-    params: &[T],
-    args: &[Expr],
-) {
-    if args.len() != params.len() {
-        diags.push(Diagnostic::new(
-            format!(
-                "too {} arguments passed to function: expected {}, but got {}",
-                if args.len() < params.len() {
-                    "few"
-                } else {
-                    "many"
-                },
-                params.len(),
-                args.len()
-            ),
-            call_span,
-        ));
-    }
-
-    params
-        .iter()
-        .zip(args)
-        .filter(|(param, arg)| !match_types(arg.tp(), param.as_ref()))
-        .map(|(param, arg)| {
-            Diagnostic::new(
-                format!(
-                    "argument type mismatch: expected {}, but got {}",
-                    param.as_ref(),
-                    arg.tp()
-                ),
-                arg.span(),
-            )
-        })
-        .for_each(|diag| diags.push(diag));
-}
-
 /// Initialize context with functions from AST
-fn ctx_from_ast(ast: &AST) -> Ctx {
+fn ctx_from_ast(ast: &AST) -> DeclTypeMap {
     ScopedMap::with_scope(
         ast.iter()
             .map(|decl| (decl.0.clone(), Rc::new(decl.1.full_type())))
@@ -372,18 +426,21 @@ impl Pass for Typing {
     type Input = TranslationUnit;
     type Output = TranslationUnit;
 
-    fn run(&mut self, (mut ast, typemap): Self::Input) -> Res<Self::Output> {
-        let mut diags = vec![];
+    fn run(&mut self, (mut ast, alias_map): Self::Input) -> Res<Self::Output> {
+        let mut typing_impl = TypingImpl {
+            diags: vec![],
+            typemap: ctx_from_ast(&ast),
+            alias_map: &alias_map,
+        };
 
-        let mut ctx = ctx_from_ast(&ast);
         for decl in ast.values_mut() {
-            type_decl_body(&mut diags, &mut ctx, decl);
+            typing_impl.type_decl_body(decl);
         }
 
-        if diags.is_empty() {
-            Res::Ok((ast, typemap))
+        if typing_impl.diags.is_empty() {
+            Res::Ok((ast, alias_map))
         } else {
-            Res::Fatal(diags)
+            Res::Fatal(typing_impl.diags)
         }
     }
 }

--- a/frontend/src/sema/passes/typing.rs
+++ b/frontend/src/sema/passes/typing.rs
@@ -293,7 +293,7 @@ impl<'a> TypingImpl<'a> {
     fn get_member_type(&self, target: &Expr, member: &str) -> Option<Rc<Type>> {
         match self.unalias_type(target.tp()) {
             Type::Bottom => Some(Rc::new(Type::Bottom)),
-            Type::Struct(fields) => fields
+            Type::Struct { fields, .. } => fields
                 .iter()
                 .find(|field| field.name == member)
                 .map(|field| field.tp.value.clone()),

--- a/frontend/src/sema/passes/unalias_struct_types.rs
+++ b/frontend/src/sema/passes/unalias_struct_types.rs
@@ -1,0 +1,75 @@
+use std::rc::Rc;
+
+use super::{Pass, Res};
+
+use crate::TranslationUnit;
+use crate::TypeDeclMap;
+use crate::ast::*;
+use crate::sema::util::for_each_expr_mut;
+use crate::typesystem::Type;
+
+/// Pass to unalias single-layer type aliases to struct types.
+///
+/// For example, if `struct Foo` is defined, all references to `Foo` will be *aliases*.
+///
+/// This pass converts all these references to direct references to `struct Foo` type instead.
+///
+/// In case of aliases like `type Bar = Foo`, `Bar` is left untouched
+pub struct UnaliasStructTypes {}
+
+impl Pass for UnaliasStructTypes {
+    type Input = TranslationUnit;
+    type Output = TranslationUnit;
+
+    fn run(&mut self, (mut ast, type_decl_map): Self::Input) -> Res<Self::Output> {
+        for decl in ast.values_mut() {
+            unalias_struct_types_in_decl(&type_decl_map, decl);
+        }
+
+        Res::Ok((ast, type_decl_map))
+    }
+}
+
+fn unalias_struct_types_in_decl(type_decl_map: &TypeDeclMap, decl: &mut FnDecl) {
+    for param in decl.params.iter_mut() {
+        let tp = &mut param.tp.value;
+        if let Type::Alias(name) = tp.as_ref() {
+            if let Some(unaliased) = unalias_struct_type(type_decl_map, name) {
+                *tp = unaliased;
+            }
+        }
+    }
+
+    for_each_expr_mut(
+        &mut unalias_struct_types_in_expr(type_decl_map),
+        &mut decl.body,
+    )
+}
+
+fn unalias_struct_types_in_expr(type_decl_map: &TypeDeclMap) -> impl FnMut(&mut Expr) {
+    |e: &mut Expr| match e {
+        Expr::Declare { tp, .. } => {
+            if let Type::Alias(name) = tp.value.as_ref() {
+                if let Some(unaliased) = unalias_struct_type(type_decl_map, name) {
+                    tp.value = unaliased;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn unalias_struct_type(type_decl_map: &TypeDeclMap, name: &str) -> Option<Rc<Type>> {
+    let tp = &type_decl_map
+        .get_decl(name)
+        .expect("valid type declaration, see `TypeNameCorrectnessCheck` pass")
+        .value
+        .value;
+
+    match tp.as_ref() {
+        Type::Struct {
+            name: struct_name, ..
+        } if struct_name.value == name => Some(tp.clone()),
+        _ => None,
+    }
+}

--- a/frontend/src/sema/util.rs
+++ b/frontend/src/sema/util.rs
@@ -1,10 +1,9 @@
 use crate::ast::Expr;
 
-/// Utilitary function to visit the whole expression tree and run some context-free function on each node.
-///
-/// The function should be context-free because there is no options to, for example, enter and leave scopes when entering a block. This functionality needs a more sophisticated system to work.
+/// Utilitary function to visit the whole expression tree and run some function on each node.
 pub fn for_each_expr(f: &mut impl FnMut(&Expr), root: &Expr) {
     f(root);
+
     match root {
         Expr::Declare { value, .. } => for_each_expr(f, value),
         Expr::Ret { value, .. } => {
@@ -38,6 +37,47 @@ pub fn for_each_expr(f: &mut impl FnMut(&Expr), root: &Expr) {
         Expr::Binary { lhs, rhs, .. } => {
             for_each_expr(f, lhs);
             for_each_expr(f, rhs);
+        }
+    }
+}
+
+/// Utilitary function to visit the whole expression tree and run some function on each node.
+pub fn for_each_expr_mut(f: &mut impl FnMut(&mut Expr), root: &mut Expr) {
+    f(root);
+
+    match root {
+        Expr::Declare { value, .. } => for_each_expr_mut(f, value),
+        Expr::Ret { value, .. } => {
+            if let Some(value) = value {
+                for_each_expr_mut(f, value);
+            }
+        }
+        Expr::While { cond, body, .. } => {
+            for_each_expr_mut(f, cond);
+            for_each_expr_mut(f, body);
+        }
+        Expr::If {
+            cond,
+            on_true,
+            on_false,
+            ..
+        } => {
+            for_each_expr_mut(f, cond);
+            for_each_expr_mut(f, on_true);
+            if let Some(on_false) = on_false {
+                for_each_expr_mut(f, on_false);
+            }
+        }
+        Expr::Block { body, .. } => body.iter_mut().for_each(|e| for_each_expr_mut(f, e)),
+        Expr::Num { .. } | Expr::Ref { .. } | Expr::Bool { .. } => {}
+        Expr::MemberRef { target, .. } => for_each_expr_mut(f, target),
+        Expr::Call { callee, args, .. } => {
+            for_each_expr_mut(f, callee);
+            args.iter_mut().for_each(|e| for_each_expr_mut(f, e));
+        }
+        Expr::Binary { lhs, rhs, .. } => {
+            for_each_expr_mut(f, lhs);
+            for_each_expr_mut(f, rhs);
         }
     }
 }

--- a/frontend/src/sema/util.rs
+++ b/frontend/src/sema/util.rs
@@ -28,10 +28,9 @@ pub fn for_each_expr(f: &mut impl FnMut(&Expr), root: &Expr) {
                 for_each_expr(f, on_false);
             }
         }
-        Expr::Block { body, .. } => {
-            body.iter().for_each(|e| for_each_expr(f, e));
-        }
+        Expr::Block { body, .. } => body.iter().for_each(|e| for_each_expr(f, e)),
         Expr::Num { .. } | Expr::Ref { .. } | Expr::Bool { .. } => {}
+        Expr::MemberRef { target, .. } => for_each_expr(f, target),
         Expr::Call { callee, args, .. } => {
             for_each_expr(f, callee);
             args.iter().for_each(|e| for_each_expr(f, e));

--- a/frontend/src/support/scoped_map.rs
+++ b/frontend/src/support/scoped_map.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 /// A stack of `HashMap`s, useful for collecting some scoped information with shadowing, like variable types.
@@ -126,5 +127,21 @@ where
         Q: Hash + Eq + ?Sized,
     {
         self.repr.iter().any(|m| m.contains_key(k))
+    }
+}
+
+impl<K: Debug, V: Debug> Debug for ScopedMap<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for (i, scope) in self.repr.iter().enumerate() {
+            if !first {
+                write!(f, "\n")?;
+            }
+
+            write!(f, "{}: {:?}", i, scope)?;
+            first = false;
+        }
+
+        Ok(())
     }
 }

--- a/frontend/src/support/scoped_set.rs
+++ b/frontend/src/support/scoped_set.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 /// A stack of `HashSet`s, useful for checking names in nested scopes.
@@ -80,5 +81,21 @@ where
         Q: Hash + Eq + ?Sized,
     {
         self.repr.iter().any(|m| m.contains(x))
+    }
+}
+
+impl<T: Debug> Debug for ScopedSet<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for (i, scope) in self.repr.iter().enumerate() {
+            if !first {
+                write!(f, "\n")?;
+            }
+
+            write!(f, "{}: {:?}", i, scope)?;
+            first = false;
+        }
+
+        Ok(())
     }
 }

--- a/frontend/src/translation_unit.rs
+++ b/frontend/src/translation_unit.rs
@@ -1,7 +1,76 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use crate::ast::AST;
-use crate::typesystem::TypeDecl;
+use crate::typesystem::{Type, TypeDecl};
 
-pub type TypeAliasMap = HashMap<String, TypeDecl>;
-pub type TranslationUnit = (AST, TypeAliasMap);
+pub type TranslationUnit = (AST, TypeDeclMap);
+
+/// Map with all the type declarations, such as type aliases and structs.
+pub struct TypeDeclMap {
+    repr: HashMap<String, TypeDecl>,
+}
+
+impl TypeDeclMap {
+    /// Create a new empty `TypeDeclMap`.
+    pub fn new() -> Self {
+        Self {
+            repr: HashMap::new(),
+        }
+    }
+
+    /// Check if the map contains type declaration with given name.
+    pub fn contains(&self, name: &str) -> bool {
+        self.repr.contains_key(name)
+    }
+
+    /// Try and find type declaration by its name.
+    pub fn get_decl(&self, name: &str) -> Option<&TypeDecl> {
+        self.repr.get(name)
+    }
+
+    /// Insert a new type declaration into the map.
+    pub fn insert_decl(&mut self, decl: TypeDecl) {
+        self.repr.insert(decl.name.value.clone(), decl);
+    }
+
+    /// Get an iterator over all declarations in the map.
+    pub fn decls(&self) -> impl Iterator<Item = &TypeDecl> {
+        self.repr.values()
+    }
+
+    /// Unwrap any type alias chains (even empty ones) until we get a concrete type.
+    ///
+    /// IMPORTANT: this method panics if provided with an invalid alias.
+    /// We expect that all aliases are checked by the respective pass before this functionality is used.
+    pub fn unalias_type<'a>(&'a self, tp: &'a Type) -> &'a Type {
+        let mut cur = tp;
+        while let Type::Alias(name) = cur {
+            let typedecl = self
+                .repr
+                .get(name)
+                .expect("expected valid type alias, see `TypeNameCorrectnessCheck` pass");
+
+            cur = typedecl.value.value.as_ref();
+        }
+
+        cur
+    }
+
+    /// Unwrap any type alias chains (even empty ones) until we get a concrete type and return it in `Rc`.
+    ///
+    /// IMPORTANT: this method panics if provided with an invalid alias.
+    /// We expect that all aliases are checked by the respective pass before this functionality is used.
+    pub fn unalias_type_rc(&self, tp: Rc<Type>) -> Rc<Type> {
+        let mut cur = tp;
+        while let Type::Alias(name) = cur.as_ref() {
+            let typedecl = self
+                .repr
+                .get(name)
+                .expect("expected valid type alias, see `TypeNameCorrectnessCheck` pass");
+
+            cur = typedecl.value.value.clone();
+        }
+        cur
+    }
+}

--- a/frontend/src/translation_unit/mod.rs
+++ b/frontend/src/translation_unit/mod.rs
@@ -1,0 +1,6 @@
+mod type_decl_map;
+pub use type_decl_map::{TypeAliasChainIterator, TypeDeclMap};
+
+use crate::ast::AST;
+
+pub type TranslationUnit = (AST, TypeDeclMap);

--- a/frontend/src/translation_unit/type_decl_map.rs
+++ b/frontend/src/translation_unit/type_decl_map.rs
@@ -1,10 +1,6 @@
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::{collections::HashMap, rc::Rc};
 
-use crate::ast::AST;
 use crate::typesystem::{Type, TypeDecl};
-
-pub type TranslationUnit = (AST, TypeDeclMap);
 
 /// Map with all the type declarations, such as type aliases and structs.
 pub struct TypeDeclMap {
@@ -34,9 +30,24 @@ impl TypeDeclMap {
         self.repr.insert(decl.name.value.clone(), decl);
     }
 
-    /// Get an iterator over all declarations in the map.
+    /// Get an iterator over immurable references to all declarations in the map.
     pub fn decls(&self) -> impl Iterator<Item = &TypeDecl> {
         self.repr.values()
+    }
+
+    /// Get an iterator over mutable references to all declarations in the map.
+    pub fn decls_mut(&mut self) -> impl Iterator<Item = &mut TypeDecl> {
+        self.repr.values_mut()
+    }
+
+    /// Get a type alias chain iterator in the context of given map and starting from `tp`.
+    ///
+    /// For more information, see `TypeAliasChainIterator`.
+    pub fn get_type_alias_chain<'a>(&'a self, tp: &'a Type) -> TypeAliasChainIterator<'a> {
+        TypeAliasChainIterator {
+            map: self,
+            cur_type: Some(tp),
+        }
     }
 
     /// Unwrap any type alias chains (even empty ones) until we get a concrete type.
@@ -72,5 +83,31 @@ impl TypeDeclMap {
             cur = typedecl.value.value.clone();
         }
         cur
+    }
+}
+
+/// Iterator over chain of type aliases.
+///
+/// For example, given that `Foo = Bar`, `Bar = Baz`, `Baz = bool`, iterator will produce `Foo` -> `Bar` -> `Baz` -> `bool`.
+pub struct TypeAliasChainIterator<'a> {
+    map: &'a TypeDeclMap,
+    cur_type: Option<&'a Type>,
+}
+
+impl<'a> Iterator for TypeAliasChainIterator<'a> {
+    type Item = &'a Type;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.cur_type?;
+
+        self.cur_type = match res {
+            Type::Alias(name) => self
+                .map
+                .get_decl(name)
+                .map(|decl| decl.value.value.as_ref()),
+            _ => None,
+        };
+
+        Some(res)
     }
 }

--- a/frontend/src/typesystem/mod.rs
+++ b/frontend/src/typesystem/mod.rs
@@ -74,10 +74,7 @@ impl Display for Type {
                 }
                 write!(f, ") -> {}", rettype)
             }
-            Type::Struct { .. } => {
-                // this is odd, but valid, because we have no anonymous structs
-                unreachable!()
-            }
+            Type::Struct { name, .. } => write!(f, "{}", name.value),
         }
     }
 }

--- a/frontend/src/typesystem/mod.rs
+++ b/frontend/src/typesystem/mod.rs
@@ -74,15 +74,9 @@ impl Display for Type {
                 }
                 write!(f, ") -> {}", rettype)
             }
-            Type::Struct{name, fields} => {
-                write!(f, "struct {} {{", name.value)?;
-                if let Some((last, init)) = fields.split_last() {
-                    for field in init {
-                        write!(f, "{}: {}, ", field.name, field.tp.value)?;
-                    }
-                    write!(f, "{}: {}", last.name, last.tp.value)?;
-                }
-                write!(f, "}}")
+            Type::Struct { .. } => {
+                // this is odd, but valid, because we have no anonymous structs
+                unreachable!()
             }
         }
     }

--- a/frontend/src/typesystem/mod.rs
+++ b/frontend/src/typesystem/mod.rs
@@ -60,7 +60,7 @@ impl Display for Type {
             Type::I64 => write!(f, "i64"),
             Type::Bool => write!(f, "bool"),
             Type::Undef => write!(f, "?"),
-            Type::Alias(name) => write!(f, "alias `{}`", name),
+            Type::Alias(name) => write!(f, "{}", name),
             Type::Function { params, rettype } => {
                 write!(f, "fn (")?;
                 if let Some((last_param, init)) = params.split_last() {

--- a/frontend/src/typesystem/mod.rs
+++ b/frontend/src/typesystem/mod.rs
@@ -22,7 +22,10 @@ pub enum Type {
         params: Vec<Rc<Type>>,
         rettype: Rc<Type>,
     },
-    Struct(Vec<Field>),
+    Struct {
+        name: WithSpan<String>,
+        fields: Vec<Field>,
+    },
     Alias(String),
     Undef,
 }
@@ -71,8 +74,8 @@ impl Display for Type {
                 }
                 write!(f, ") -> {}", rettype)
             }
-            Type::Struct(fields) => {
-                write!(f, "struct {{")?;
+            Type::Struct{name, fields} => {
+                write!(f, "struct {} {{", name.value)?;
                 if let Some((last, init)) = fields.split_last() {
                     for field in init {
                         write!(f, "{}: {}, ", field.name, field.tp.value)?;

--- a/opt/src/translator/mod.rs
+++ b/opt/src/translator/mod.rs
@@ -183,7 +183,7 @@ impl ASTTranslator {
                 self.translate_binary(func, defs, op.value, lhs, rhs)
             }
             Expr::Block { body, .. } => self.translate_block(func, defs, body),
-            Expr::While { .. } | Expr::If { .. } => todo!(),
+            Expr::MemberRef { .. } | Expr::While { .. } | Expr::If { .. } => todo!(),
         }
     }
 
@@ -226,7 +226,10 @@ impl Translator<AST> for ASTTranslator {
             .map(|(name, func)| {
                 (
                     name.clone(),
-                    Rc::new(Var::new(func.name.value.clone(), func.return_type.value.clone())),
+                    Rc::new(Var::new(
+                        func.name.value.clone(),
+                        func.return_type.value.clone(),
+                    )),
                 )
             })
             .collect();


### PR DESCRIPTION
Treat type aliases as subtypes of the type they alias to, add check for alias initializer loops.

Depends on PRs #34 and #35, review them first.