### PR TITLE
Block parsing microfix

### DIFF
--- a/frontend/src/parser/mod.rs
+++ b/frontend/src/parser/mod.rs
@@ -553,6 +553,8 @@ impl Parser {
             .span
             .start;
 
+        self.eat_while(token!(Token::EOL));
+
         let mut body = Vec::new();
         while self.lexemes.peek().value != Token::RBrace {
             self.eat_while(token!(Token::EOL));


### PR DESCRIPTION
Fix parsing of empty blocks with `}` on a different line than `{`